### PR TITLE
changed dependency to q10

### DIFF
--- a/aicp.dependencies
+++ b/aicp.dependencies
@@ -2,6 +2,6 @@
   {
     "repository":  "AICP/device_oneplus_msm8998-common",
     "target_path": "device/oneplus/msm8998-common",
-    "branch":      "p9.0"
+    "branch":      "q10.0"
   }
 ]


### PR DESCRIPTION
Choosing any aicp_dumpling build with `lunch` would end up in mixed Pie & Q dependencies for this device and this change fixed the problem.